### PR TITLE
Master build from repo truiz

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,13 @@
-# Put the image name according to the version
+## Put the image name according to the version
 FROM vauxoo/odoo-80-image
 
-# Remember to put you name
+## Remember to put you name
 MAINTAINER Your Name <mail@example.com>
 
-# Change the version to the correspondig one
+## Change the version to the correspondig one
 ENV VERSION 8.0
 
-# Change the repor according to the customer app repo
+## Change the repo according to the customer app repo
 ENV APP_REPO git@github.com:Vauxoo/app_repo.git
 
 RUN adduser --home=/home/odoo --disabled-password --gecos "" --shell=/bin/bash odoo \
@@ -17,7 +17,7 @@ RUN adduser --home=/home/odoo --disabled-password --gecos "" --shell=/bin/bash o
     && mkdir /external_files
 
 ## This is a key you must copy in the same folder as the dockerfile
-## bur remember not to add it when you commit the files
+## but remember not to add it when you commit the files
 COPY id_rsa /home/odoo/.ssh/id_rsa
 COPY id_rsa /root/.ssh/id_rsa
 
@@ -50,7 +50,9 @@ RUN /bin/bash -c "mkdir -p /home/odoo/instance/{config,extra_addons}" \
     && rm /home/odoo/.ssh/id_rsa \
     && mkdir -p /home/odoo/.local/share
 COPY files/openerp_serverrc /home/odoo/.openerp_serverrc
+
 USER root
+## Actually here is where the instance is build
 RUN pip install --upgrade pip \
     && ssh-keyscan github.com > /root/.ssh/known_hosts \
     && cd /home/odoo/instance/extra_addons \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,25 +1,40 @@
+# Put the image name according to the version
 FROM vauxoo/odoo-80-image
 
 # Remember to put you name
 MAINTAINER Your Name <mail@example.com>
+
+# Change the version to the correspondig one
+ENV VERSION 8.0
+
+# Change the repor according to the customer app repo
+ENV APP_REPO git@github.com:Vauxoo/app_repo.git
+
 RUN adduser --home=/home/odoo --disabled-password --gecos "" --shell=/bin/bash odoo
 RUN echo 'root:odoo' |chpasswd
-RUN mkdir /home/odoo/.ssh
+RUN mkdir -p /home/odoo/.ssh \
+    && mkdir -p /root/.ssh
 
 ## This is a key you must copy in the same folder as the dockerfile
 ## bur remember not to add it when you commit the files
-COPY id_rsa /home/odoo/.ssh/id_rsa
+ADD id_rsa /home/odoo/.ssh/id_rsa
+ADD id_rsa /root/.ssh/id_rsa
 
-RUN chown odoo:odoo -R /home/odoo \
-    && chmod 600 /home/odoo/.ssh/id_rsa
-COPY files/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+RUN chown odoo:odoo -R /home/odoo/.ssh \
+    && chmod 600 /home/odoo/.ssh/id_rsa \
+    && chmod 600 /root/.ssh/id_rsa
+
+ADD files/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 RUN mkdir /external_files
-COPY files/supervisord.conf /external_files/supervisord.conf
-COPY files/openerp_serverrc /external_files/openerp_serverrc
+ADD files/supervisord.conf /external_files/supervisord.conf
+ADD files/openerp_serverrc /external_files/openerp_serverrc
+ADD files/build_branches.sh /tmp/build_branches.sh
+
 USER odoo
 ENV HOME /home/odoo
 ENV ODOO_CONFIG_FILE /home/odoo/.openerp_serverrc
-ENV ODOO_FILESTORE_PATH /home/odoo/.local/share/Odoo/filestore 
+ENV ODOO_FILESTORE_PATH /home/odoo/.local/share/Odoo/filestore
 
 ## Scan the keys to avoid the add question
 RUN ssh-keyscan github.com > /home/odoo/.ssh/known_hosts \
@@ -28,18 +43,23 @@ RUN ssh-keyscan github.com > /home/odoo/.ssh/known_hosts \
 
 ## Make the instance folder structure
 RUN /bin/bash -c "mkdir -p /home/odoo/instance/{config,extra_addons}"
-RUN cd /home/odoo/instance && git clone -b 8.0 --single-branch --depth=1 git@github.com:Vauxoo/odoo.git odoo
-
-## Add the repos you want to use
-RUN cd /home/odoo/instance/extra_addons \
-    && git clone -b 8.0 --single-branch --depth=1 git@github.com:Organization/repo.git repo_folder_name
+RUN cd /home/odoo/instance \
+    && git clone -b $VERSION --single-branch --depth=1 git@github.com:Vauxoo/odoo.git odoo
 
 ## Remove the key file you added before
-RUN rm /home/odoo/.ssh/id_rsa
-RUN mkdir -p /home/odoo/.local/share
+RUN rm /home/odoo/.ssh/id_rsa \
+    && mkdir -p /home/odoo/.local/share
 ENV XDG_DATA_HOME /home/odoo/.local/share
-COPY files/openerp_serverrc /home/odoo/.openerp_serverrc
+ADD files/openerp_serverrc /home/odoo/.openerp_serverrc
 USER root
+RUN pip install --upgrade pip \
+    && ssh-keyscan github.com > /root/.ssh/known_hosts \
+    && cd /home/odoo/instance/extra_addons \
+    && git clone -b $VERSION --single-branch --depth=1 $APP_REPO \
+    && sh /tmp/build_branches.sh \
+    && chown odoo:odoo -R /home/odoo \
+    && rm -f /root/.ssh/id_rsa \
+    && rm -r /tmp/*
 RUN mkdir -p /var/log/supervisor
 RUN wget -q -O /entry_point.py https://raw.githubusercontent.com/vauxoo/docker_entrypoint/master/entry_point.py \
     && chmod +x /entry_point.py

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,23 +13,23 @@ ENV APP_REPO git@github.com:Vauxoo/app_repo.git
 RUN adduser --home=/home/odoo --disabled-password --gecos "" --shell=/bin/bash odoo
 RUN echo 'root:odoo' |chpasswd
 RUN mkdir -p /home/odoo/.ssh \
-    && mkdir -p /root/.ssh
+    && mkdir -p /root/.ssh \
+    && mkdir /external_files
 
 ## This is a key you must copy in the same folder as the dockerfile
 ## bur remember not to add it when you commit the files
-ADD id_rsa /home/odoo/.ssh/id_rsa
-ADD id_rsa /root/.ssh/id_rsa
+COPY id_rsa /home/odoo/.ssh/id_rsa
+COPY id_rsa /root/.ssh/id_rsa
 
 
 RUN chown odoo:odoo -R /home/odoo/.ssh \
     && chmod 600 /home/odoo/.ssh/id_rsa \
     && chmod 600 /root/.ssh/id_rsa
 
-ADD files/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-RUN mkdir /external_files
-ADD files/supervisord.conf /external_files/supervisord.conf
-ADD files/openerp_serverrc /external_files/openerp_serverrc
-ADD files/build_branches.sh /tmp/build_branches.sh
+COPY files/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY files/supervisord.conf /external_files/supervisord.conf
+COPY files/openerp_serverrc /external_files/openerp_serverrc
+COPY files/build_branches.sh /tmp/build_branches.sh
 
 USER odoo
 ENV HOME /home/odoo
@@ -50,7 +50,7 @@ RUN cd /home/odoo/instance \
 RUN rm /home/odoo/.ssh/id_rsa \
     && mkdir -p /home/odoo/.local/share
 ENV XDG_DATA_HOME /home/odoo/.local/share
-ADD files/openerp_serverrc /home/odoo/.openerp_serverrc
+COPY files/openerp_serverrc /home/odoo/.openerp_serverrc
 USER root
 RUN pip install --upgrade pip \
     && ssh-keyscan github.com > /root/.ssh/known_hosts \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,9 +10,9 @@ ENV VERSION 8.0
 # Change the repor according to the customer app repo
 ENV APP_REPO git@github.com:Vauxoo/app_repo.git
 
-RUN adduser --home=/home/odoo --disabled-password --gecos "" --shell=/bin/bash odoo
-RUN echo 'root:odoo' |chpasswd
-RUN mkdir -p /home/odoo/.ssh \
+RUN adduser --home=/home/odoo --disabled-password --gecos "" --shell=/bin/bash odoo \
+    && echo 'root:odoo' |chpasswd \
+    && mkdir -p /home/odoo/.ssh \
     && mkdir -p /root/.ssh \
     && mkdir /external_files
 
@@ -32,9 +32,11 @@ COPY files/openerp_serverrc /external_files/openerp_serverrc
 COPY files/build_branches.sh /tmp/build_branches.sh
 
 USER odoo
-ENV HOME /home/odoo
-ENV ODOO_CONFIG_FILE /home/odoo/.openerp_serverrc
-ENV ODOO_FILESTORE_PATH /home/odoo/.local/share/Odoo/filestore
+ENV HOME="/home/odoo" \
+    ODOO_CONFIG_FILE="/home/odoo/.openerp_serverrc" \
+    ODOO_FILESTORE_PATH="/home/odoo/.local/share/Odoo/filestore" \
+    XDG_DATA_HOME="/home/odoo/.local/share"
+
 
 ## Scan the keys to avoid the add question
 RUN ssh-keyscan github.com > /home/odoo/.ssh/known_hosts \
@@ -42,14 +44,11 @@ RUN ssh-keyscan github.com > /home/odoo/.ssh/known_hosts \
     && ssh-keyscan bitbucket.org >> /home/odoo/.ssh/known_hosts
 
 ## Make the instance folder structure
-RUN /bin/bash -c "mkdir -p /home/odoo/instance/{config,extra_addons}"
-RUN cd /home/odoo/instance \
-    && git clone -b $VERSION --single-branch --depth=1 git@github.com:Vauxoo/odoo.git odoo
-
-## Remove the key file you added before
-RUN rm /home/odoo/.ssh/id_rsa \
+RUN /bin/bash -c "mkdir -p /home/odoo/instance/{config,extra_addons}" \
+    && /home/odoo/instance \
+    && git clone -b $VERSION --single-branch --depth=1 git@github.com:Vauxoo/odoo.git odoo \
+    && rm /home/odoo/.ssh/id_rsa \
     && mkdir -p /home/odoo/.local/share
-ENV XDG_DATA_HOME /home/odoo/.local/share
 COPY files/openerp_serverrc /home/odoo/.openerp_serverrc
 USER root
 RUN pip install --upgrade pip \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,12 +18,9 @@ RUN adduser --home=/home/odoo --disabled-password --gecos "" --shell=/bin/bash o
 
 ## This is a key you must copy in the same folder as the dockerfile
 ## but remember not to add it when you commit the files
-COPY id_rsa /home/odoo/.ssh/id_rsa
 COPY id_rsa /root/.ssh/id_rsa
 
-
 RUN chown odoo:odoo -R /home/odoo/.ssh \
-    && chmod 600 /home/odoo/.ssh/id_rsa \
     && chmod 600 /root/.ssh/id_rsa
 
 COPY files/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
@@ -43,18 +40,16 @@ RUN ssh-keyscan github.com > /home/odoo/.ssh/known_hosts \
     && ssh-keyscan launchpad.net >> /home/odoo/.ssh/known_hosts \
     && ssh-keyscan bitbucket.org >> /home/odoo/.ssh/known_hosts
 
-## Make the instance folder structure
-RUN /bin/bash -c "mkdir -p /home/odoo/instance/{config,extra_addons}" \
-    && /home/odoo/instance \
-    && git clone -b $VERSION --single-branch --depth=1 git@github.com:Vauxoo/odoo.git odoo \
-    && rm /home/odoo/.ssh/id_rsa \
-    && mkdir -p /home/odoo/.local/share
-COPY files/openerp_serverrc /home/odoo/.openerp_serverrc
-
 USER root
 ## Actually here is where the instance is build
-RUN pip install --upgrade pip \
-    && ssh-keyscan github.com > /root/.ssh/known_hosts \
+## Make the instance folder structure
+COPY files/openerp_serverrc /home/odoo/.openerp_serverrc
+RUN ssh-keyscan github.com > /root/.ssh/known_hosts \
+    && /bin/bash -c "mkdir -p /home/odoo/instance/{config,extra_addons}" \
+    && cd /home/odoo/instance \
+    && git clone -b $VERSION --single-branch --depth=1 git@github.com:Vauxoo/odoo.git odoo \
+    && mkdir -p /home/odoo/.local/share \
+    && pip install --upgrade pip \
     && cd /home/odoo/instance/extra_addons \
     && git clone -b $VERSION --single-branch --depth=1 $APP_REPO \
     && sh /tmp/build_branches.sh \

--- a/docker/files/build_branches.sh
+++ b/docker/files/build_branches.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+cd /tmp
+git clone -b master https://github.com/OCA/maintainer-quality-tools
+python maintainer-quality-tools/travis/clone_oca_dependencies /home/odoo/instance/extra_addons /home/odoo/instance/extra_addons
+ADDONS="$(python maintainer-quality-tools/travis/getaddons.py /home/odoo/instance/extra_addons)"
+sed -ri "s%(addons_path).*$%\1 = /home/odoo/instance/odoo/addons,$ADDONS%g" /home/odoo/.openerp_serverrc


### PR DESCRIPTION
Now it is easier to build the image since only have to add the app repo and the version (8.0, 9.0...) and all dependencies are handled by oca scripts (requirements.txt and others repos).

The addons path is updated with all the config too and updated to use COPY instead of ADD for adding files to the build.

A few optimizations were made to save a few layers in the build but that's not strictly needed because the images built with this dockerfile are the lasts in the tree (or the second-last)
